### PR TITLE
Fix breaking change with the ng upgrade to version 1.7.0rc0

### DIFF
--- a/dist/angular-gettext.js
+++ b/dist/angular-gettext.js
@@ -295,8 +295,8 @@ angular.module('gettext').factory('gettextCatalog', ["gettextPlurals", "gettextF
         getString: function (string, scope, context) {
             var fallbackLanguage = gettextFallbackLanguage(this.currentLanguage);
             string = this.getStringFormFor(this.currentLanguage, string, 1, context) ||
-                     this.getStringFormFor(fallbackLanguage, string, 1, context) ||
-                     prefixDebug(string);
+                this.getStringFormFor(fallbackLanguage, string, 1, context) ||
+                prefixDebug(string);
             string = scope ? $interpolate(string)(scope) : string;
             return addTranslatedMarkers(string);
         },
@@ -317,8 +317,8 @@ angular.module('gettext').factory('gettextCatalog', ["gettextPlurals", "gettextF
         getPlural: function (n, string, stringPlural, scope, context) {
             var fallbackLanguage = gettextFallbackLanguage(this.currentLanguage);
             string = this.getStringFormFor(this.currentLanguage, string, n, context) ||
-                     this.getStringFormFor(fallbackLanguage, string, n, context) ||
-                     prefixDebug(n === 1 ? string : stringPlural);
+                this.getStringFormFor(fallbackLanguage, string, n, context) ||
+                prefixDebug(n === 1 ? string : stringPlural);
             if (scope) {
                 scope.$count = n;
                 string = $interpolate(string)(scope);
@@ -410,6 +410,9 @@ angular.module('gettext').factory('gettextCatalog', ["gettextPlurals", "gettextF
  * ```
  */
 angular.module('gettext').directive('translate', ["gettextCatalog", "$parse", "$animate", "$compile", "$window", "gettextUtil", function (gettextCatalog, $parse, $animate, $compile, $window, gettextUtil) {
+    function isString(value) { return typeof value === 'string'; }
+    var lowercase = function (string) { return isString(string) ? string.toLowerCase() : string; };
+
     var msie = parseInt((/msie (\d+)/.exec(angular.lowercase($window.navigator.userAgent)) || [])[1], 10);
     var PARAMS_PREFIX = 'translateParams';
 
@@ -484,14 +487,14 @@ angular.module('gettext').directive('translate', ["gettextCatalog", "$parse", "$
                         }
                         var oldContents = element.contents();
 
-                        if (!oldContents && !translated){
+                        if (!oldContents && !translated) {
                             return;
                         }
 
                         // Avoid redundant swaps
-                        if (translated === gettextUtil.trim(oldContents.html())){
+                        if (translated === gettextUtil.trim(oldContents.html())) {
                             // Take care of unlinked content
-                            if (linking){
+                            if (linking) {
                                 $compile(oldContents)(scope);
                             }
                             return;
@@ -630,13 +633,13 @@ angular.module("gettext").factory("gettextPlurals", function () {
                 return 0;
             case "is":  // Icelandic
                 // 2 forms
-                return (n%10!=1 || n%100==11) ? 1 : 0;
+                return (n % 10 != 1 || n % 100 == 11) ? 1 : 0;
             case "jv":  // Javanese
                 // 2 forms
-                return n!=0 ? 1 : 0;
+                return n != 0 ? 1 : 0;
             case "mk":  // Macedonian
                 // 2 forms
-                return n==1 || n%10==1 ? 0 : 1;
+                return n == 1 || n % 10 == 1 ? 0 : 1;
             case "ach": // Acholi
             case "ak":  // Akan
             case "am":  // Amharic
@@ -658,13 +661,13 @@ angular.module("gettext").factory("gettextPlurals", function () {
             case "wa":  // Walloon
             case "zh":  // Chinese
                 // 2 forms
-                return n>1 ? 1 : 0;
+                return n > 1 ? 1 : 0;
             case "lv":  // Latvian
                 // 3 forms
-                return (n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);
+                return (n % 10 == 1 && n % 100 != 11 ? 0 : n != 0 ? 1 : 2);
             case "lt":  // Lithuanian
                 // 3 forms
-                return (n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);
+                return (n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2);
             case "be":  // Belarusian
             case "bs":  // Bosnian
             case "hr":  // Croatian
@@ -672,41 +675,41 @@ angular.module("gettext").factory("gettextPlurals", function () {
             case "sr":  // Serbian
             case "uk":  // Ukrainian
                 // 3 forms
-                return (n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
+                return (n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2);
             case "mnk": // Mandinka
                 // 3 forms
-                return (n==0 ? 0 : n==1 ? 1 : 2);
+                return (n == 0 ? 0 : n == 1 ? 1 : 2);
             case "ro":  // Romanian
                 // 3 forms
-                return (n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);
+                return (n == 1 ? 0 : (n == 0 || (n % 100 > 0 && n % 100 < 20)) ? 1 : 2);
             case "pl":  // Polish
                 // 3 forms
-                return (n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
+                return (n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2);
             case "cs":  // Czech
             case "sk":  // Slovak
                 // 3 forms
-                return (n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;
+                return (n == 1) ? 0 : (n >= 2 && n <= 4) ? 1 : 2;
             case "sl":  // Slovenian
                 // 4 forms
-                return (n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0);
+                return (n % 100 == 1 ? 1 : n % 100 == 2 ? 2 : n % 100 == 3 || n % 100 == 4 ? 3 : 0);
             case "mt":  // Maltese
                 // 4 forms
-                return (n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3);
+                return (n == 1 ? 0 : n == 0 || (n % 100 > 1 && n % 100 < 11) ? 1 : (n % 100 > 10 && n % 100 < 20) ? 2 : 3);
             case "gd":  // Scottish Gaelic
                 // 4 forms
-                return (n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : 3;
+                return (n == 1 || n == 11) ? 0 : (n == 2 || n == 12) ? 1 : (n > 2 && n < 20) ? 2 : 3;
             case "cy":  // Welsh
                 // 4 forms
-                return (n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3;
+                return (n == 1) ? 0 : (n == 2) ? 1 : (n != 8 && n != 11) ? 2 : 3;
             case "kw":  // Cornish
                 // 4 forms
-                return (n==1) ? 0 : (n==2) ? 1 : (n == 3) ? 2 : 3;
+                return (n == 1) ? 0 : (n == 2) ? 1 : (n == 3) ? 2 : 3;
             case "ga":  // Irish
                 // 5 forms
-                return n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4;
+                return n == 1 ? 0 : n == 2 ? 1 : n < 7 ? 2 : n < 11 ? 3 : 4;
             case "ar":  // Arabic
                 // 6 forms
-                return (n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);
+                return (n == 0 ? 0 : n == 1 ? 1 : n == 2 ? 2 : n % 100 >= 3 && n % 100 <= 10 ? 3 : n % 100 >= 11 ? 4 : 5);
             default: // Everything else
                 return n != 1 ? 1 : 0;
         }

--- a/dist/angular-gettext.js
+++ b/dist/angular-gettext.js
@@ -413,7 +413,7 @@ angular.module('gettext').directive('translate', ["gettextCatalog", "$parse", "$
     function isString(value) { return typeof value === 'string'; }
     var lowercase = function (string) { return isString(string) ? string.toLowerCase() : string; };
 
-    var msie = parseInt((/msie (\d+)/.exec(angular.lowercase($window.navigator.userAgent)) || [])[1], 10);
+    var msie = parseInt((/msie (\d+)/.exec(lowercase($window.navigator.userAgent)) || [])[1], 10);
     var PARAMS_PREFIX = 'translateParams';
 
     function getCtxAttr(key) {


### PR DESCRIPTION
In angular 1.7.0, they have removed the function angular.lowercase which is being used by gettext, so copied the angular function to gettext so it could us it locally.

Also vs code prettier extension formatted the code.